### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ async function process(markdown: string) {
     unified()
     .use(markdown)
     .use(remark2rehype)
-    .use(resolveLayoutShiftPlugin, { type: 'maxWidth', maxWidth: '800' })
+    .use(resolveLayoutShiftPlugin, { type: 'maxWidth', maxWidth: 800 })
     .use(html)
     .process(markdown, (err, file) => {
       if (err) {


### PR DESCRIPTION
I copy and paste a code from README file and got following error.

```
Type 'string' is not assignable to type 'number'.ts(2322)
index.d.ts(6, 3): The expected type comes from property 'maxWidth' which is declared here on type 'ResolveLayoutShiftPluginOptions'.
````

It turns out the `maxWidth` option is expecting number or undefined value, but  README writes it is string.

https://github.com/potato4d/rehype-plugin-auto-resolve-layout-shift/blob/d5950a97b245f62fceeed2e365d7b565dbecbbc7/src/index.ts#L13